### PR TITLE
fix docs year and "edit this page on github" link

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -11,7 +11,7 @@ export default {
   customSearch: null, // customizable, you can use algolia for example
   darkMode: true,
   footer: true,
-  footerText: 'MIT 2020 © Premier Octet.',
+  footerText: `MIT ${new Date().getFullYear()} © Premier Octet.`,
   footerEditOnGitHubLink: true, // will link to the docs repo
   logo: (
     <div className="flex items-center">

--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -2,8 +2,9 @@ import Logo from './components/Logo'
 
 export default {
   repository: 'https://github.com/premieroctet/next-crud',
+  docsRepository: 'https://github.com/premieroctet/next-crud',
   branch: 'master', // branch of docs
-  path: 'docs', // path of docs
+  path: '/docs', // path of docs
   titleSuffix: ' – Next Crud - Full-featured CRUD routes for Next.js',
   nextLinks: true,
   prevLinks: true,


### PR DESCRIPTION
I made the hardcoded year in the footer dynamic and tried to fixed the "edit tihs page on github" link since the docs repo was missing in the nextra config:

![image](https://user-images.githubusercontent.com/987947/103690033-66992a00-4f94-11eb-84aa-b4f735852ca3.png)
