### PR TITLE
Handle where filter for prisma relations

### DIFF
--- a/__tests__/adapters/prisma/utils/parseWhere.ts
+++ b/__tests__/adapters/prisma/utils/parseWhere.ts
@@ -45,7 +45,7 @@ describe('Prisma parse where', () => {
   })
 
   it('should parse $and', () => {
-    const baseQuery: TWhereField = {
+    let baseQuery: TWhereField = {
       $and: {
         username: {
           $cont: 'foo',
@@ -65,10 +65,41 @@ describe('Prisma parse where', () => {
         },
       }
     )
+
+    baseQuery = {
+      $and: {
+        username: {
+          $cont: 'foo',
+        },
+        'posts.author.id': 1,
+      },
+    }
+
+    expect(
+      parsePrismaWhere(baseQuery, ['posts.author'])
+    ).toEqual<TPrismaWhereField>(
+      // @ts-ignore
+      {
+        AND: {
+          username: {
+            contains: 'foo',
+          },
+          posts: {
+            some: {
+              author: {
+                some: {
+                  id: 1,
+                },
+              },
+            },
+          },
+        },
+      }
+    )
   })
 
   it('should parse $or', () => {
-    const baseQuery: TWhereField = {
+    let baseQuery: TWhereField = {
       $or: {
         username: {
           $cont: 'foo',
@@ -88,10 +119,41 @@ describe('Prisma parse where', () => {
         },
       }
     )
+
+    baseQuery = {
+      $or: {
+        username: {
+          $cont: 'foo',
+        },
+        'posts.author.id': 1,
+      },
+    }
+
+    expect(
+      parsePrismaWhere(baseQuery, ['posts.author'])
+    ).toEqual<TPrismaWhereField>(
+      // @ts-ignore
+      {
+        OR: {
+          username: {
+            contains: 'foo',
+          },
+          posts: {
+            some: {
+              author: {
+                some: {
+                  id: 1,
+                },
+              },
+            },
+          },
+        },
+      }
+    )
   })
 
   it('should parse $not', () => {
-    const baseQuery: TWhereField = {
+    let baseQuery: TWhereField = {
       $not: {
         username: {
           $cont: 'foo',
@@ -111,5 +173,82 @@ describe('Prisma parse where', () => {
         },
       }
     )
+
+    baseQuery = {
+      $not: {
+        username: {
+          $cont: 'foo',
+        },
+        'posts.author.id': 1,
+      },
+    }
+
+    expect(
+      parsePrismaWhere(baseQuery, ['posts.author'])
+    ).toEqual<TPrismaWhereField>(
+      // @ts-ignore
+      {
+        NOT: {
+          username: {
+            contains: 'foo',
+          },
+          posts: {
+            some: {
+              author: {
+                some: {
+                  id: 1,
+                },
+              },
+            },
+          },
+        },
+      }
+    )
+  })
+
+  it('should handle simple relations', () => {
+    const baseQuery: TWhereField = {
+      'posts.content': {
+        $cont: 'Hello',
+      },
+    }
+
+    expect(parsePrismaWhere(baseQuery, ['posts'])).toEqual<TPrismaWhereField>({
+      posts: {
+        some: {
+          content: {
+            contains: 'Hello',
+          },
+        },
+      },
+    })
+  })
+
+  it('should handle nested relations', () => {
+    const baseQuery: TWhereField = {
+      'posts.content': {
+        $cont: 'Hello',
+      },
+      'posts.author.id': 1,
+      'posts.id': 1,
+    }
+
+    expect(
+      parsePrismaWhere(baseQuery, ['posts', 'posts.author'])
+    ).toEqual<TPrismaWhereField>({
+      posts: {
+        some: {
+          id: 1,
+          content: {
+            contains: 'Hello',
+          },
+          author: {
+            some: {
+              id: 1,
+            },
+          },
+        },
+      },
+    })
   })
 })

--- a/__tests__/queryParser.ts
+++ b/__tests__/queryParser.ts
@@ -4,8 +4,9 @@ import { IParsedQueryParams } from '../src/types'
 describe('Parse select', () => {
   it('should parse simple select', () => {
     const query = 'select=user,post'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       select: {
         user: true,
         post: true,
@@ -13,10 +14,11 @@ describe('Parse select', () => {
     })
   })
 
-  it('should parse nested select', () => {
-    let query = 'select=user,post.user,post.title'
+  it('should parse nested select 2', () => {
+    const query = 'select=user,post.user,post.title'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       select: {
         user: true,
         post: {
@@ -25,10 +27,13 @@ describe('Parse select', () => {
         },
       },
     })
+  })
 
-    query = 'select=user,post.user,post.user.post'
+  it('should parse nested select 2', () => {
+    const query = 'select=user,post.user,post.user.post'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       select: {
         user: true,
         post: {
@@ -44,8 +49,9 @@ describe('Parse select', () => {
 describe('Parse include', () => {
   it('should parse simple include', () => {
     const query = 'include=user,post'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       include: {
         user: true,
         post: true,
@@ -53,10 +59,11 @@ describe('Parse include', () => {
     })
   })
 
-  it('should parse nested select', () => {
-    let query = 'include=user,post.user,post.title'
+  it('should parse nested include 1', () => {
+    const query = 'include=user,post.user,post.title'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       include: {
         user: true,
         post: {
@@ -65,10 +72,13 @@ describe('Parse include', () => {
         },
       },
     })
+  })
 
-    query = 'include=user,post.user,post.user.post'
+  it('should parse nested include 12', () => {
+    const query = 'include=user,post.user,post.user.post'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       include: {
         user: true,
         post: {
@@ -84,8 +94,9 @@ describe('Parse include', () => {
 describe('Parse where', () => {
   it('should parse a simple where condition', () => {
     const query = 'where={"username": "foo"}'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       where: {
         username: 'foo',
       },
@@ -94,8 +105,9 @@ describe('Parse where', () => {
 
   it('should parse where condition with operators', () => {
     const query = 'where={"age": {"$gt": 18}}'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       where: {
         age: { $gt: 18 },
       },
@@ -104,8 +116,9 @@ describe('Parse where', () => {
 
   it('should parse where nested field', () => {
     const query = 'where={"user.age": {"$gt": 18}}'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       where: {
         user: {
           age: {
@@ -120,8 +133,9 @@ describe('Parse where', () => {
 describe('Parse orderBy', () => {
   it('should parse a correct orderBy', () => {
     const query = 'orderBy={"username": "$asc"}'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       orderBy: {
         username: '$asc',
       },
@@ -138,16 +152,18 @@ describe('Parse orderBy', () => {
 describe('Parse limit', () => {
   it('should parse valid number', () => {
     const query = 'limit=2'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       limit: 2,
     })
   })
 
   it('should parse invalid number', () => {
     const query = 'limit=foobar'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       limit: undefined,
     })
   })
@@ -156,16 +172,18 @@ describe('Parse limit', () => {
 describe('Parse skip', () => {
   it('should parse valid number', () => {
     const query = 'skip=2'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       skip: 2,
     })
   })
 
   it('should parse invalid number', () => {
     const query = 'skip=foobar'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       skip: undefined,
     })
   })
@@ -174,8 +192,9 @@ describe('Parse skip', () => {
 describe('Parse distinct', () => {
   it('should parse distinct', () => {
     const query = 'distinct=id'
+    const { originalQuery, ...result } = parseQuery(query)
 
-    expect(parseQuery(query)).toEqual<IParsedQueryParams>({
+    expect(result).toEqual<IParsedQueryParams>({
       distinct: 'id',
     })
   })

--- a/docs/pages/api-docs/adapters.mdx
+++ b/docs/pages/api-docs/adapters.mdx
@@ -79,6 +79,10 @@ The name of the key used to retrieve the your unique resources. Defaults to `id`
 
 The options for your prisma client. See [prisma documentation](https://www.prisma.io/docs/concepts/components/prisma-client/constructor)
 
+### manyRelations
+
+An array containing all the relations and nested relations of your modal that could be queried from the `where` filter. For nested relations, split them with a `.`, e.g: `posts.author`
+
 ---
 
 ### Additional query params
@@ -88,9 +92,3 @@ The Prisma adapter allows you to use an additional query param, which is related
 #### cursor
 
 A JSON object containing only 1 key and a matching value corresponding to an entry in the database which is the starting point of the result of the query. You can see that as an offset.
-
----
-
-### Known issues
-
-Currently the Prisma adapter does not support relations on your `where` search criteria, this will be implemented in a future version.

--- a/example/pages/api/users/[[...users]].ts
+++ b/example/pages/api/users/[[...users]].ts
@@ -1,9 +1,9 @@
-import { User, UserInclude } from '@prisma/client'
+import { User } from '@prisma/client'
 import NextCrud, { PrismaAdapter } from '@premieroctet/next-crud'
 
 const handler = NextCrud({
   resourceName: 'users',
-  adapter: new PrismaAdapter<User, UserInclude>({
+  adapter: new PrismaAdapter<User>({
     modelName: 'user',
     manyRelations: ['posts'],
   }),

--- a/example/pages/api/users/[[...users]].ts
+++ b/example/pages/api/users/[[...users]].ts
@@ -1,10 +1,11 @@
-import { User } from '@prisma/client'
+import { User, UserInclude } from '@prisma/client'
 import NextCrud, { PrismaAdapter } from '@premieroctet/next-crud'
 
 const handler = NextCrud({
   resourceName: 'users',
-  adapter: new PrismaAdapter<User>({
+  adapter: new PrismaAdapter<User, UserInclude>({
     modelName: 'user',
+    manyRelations: ['posts'],
   }),
   onRequest: (req) => {
     console.log(`request occured on URL ${req.url}`)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.2"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "@prisma/client": "^2.0.0"
   },
   "husky": {

--- a/src/adapters/prisma/index.ts
+++ b/src/adapters/prisma/index.ts
@@ -18,18 +18,18 @@ import { parsePrismaOrderBy } from './utils/parseOrderBy'
 import { parsePrismaRecursiveField } from './utils/parseRecursive'
 import { parsePrismaWhere } from './utils/parseWhere'
 
-interface IAdapterCtorArgs<T, I> {
+interface IAdapterCtorArgs<T> {
   modelName: keyof PrismaClient
   primaryKey?: string
   options?: PrismaClientOptions
-  manyRelations?: Array<keyof I>
+  manyRelations?: string[]
 }
 
-export default class PrismaAdapter<T, I>
+export default class PrismaAdapter<T>
   implements IAdapter<T, IPrismaParsedQueryParams> {
   private prismaDelegate: Record<PrismaAction, (...args: any[]) => Promise<T>>
   private primaryKey: string
-  private manyRelations: Array<keyof I>
+  private manyRelations: string[]
   private prismaClient: PrismaClient
 
   constructor({
@@ -37,7 +37,7 @@ export default class PrismaAdapter<T, I>
     primaryKey = 'id',
     options,
     manyRelations = [],
-  }: IAdapterCtorArgs<T, I>) {
+  }: IAdapterCtorArgs<T>) {
     this.prismaClient = new PrismaClient(options)
     this.prismaDelegate = this.prismaClient[modelName]
     this.primaryKey = primaryKey
@@ -92,8 +92,6 @@ export default class PrismaAdapter<T, I>
     if (query.distinct) {
       parsed.distinct = query.distinct
     }
-
-    console.log('parsed where', parsed.where)
 
     return parsed
   }

--- a/src/adapters/prisma/types.ts
+++ b/src/adapters/prisma/types.ts
@@ -27,13 +27,20 @@ export type TPrismaFieldFilterOperator = {
 }
 
 export type TPrismaFieldFilter = {
-  [key: string]: TSearchCondition | TPrismaFieldFilterOperator
+  [key: string]:
+    | TSearchCondition
+    | TPrismaFieldFilterOperator
+    | TPrismaRelationFitler
 }
 
 export type TPrismaWhereField = TPrismaFieldFilter & {
   AND?: TPrismaFieldFilter
   OR?: TPrismaFieldFilter
   NOT?: TPrismaFieldFilter
+}
+
+export type TPrismaRelationFitler = {
+  some: TSearchCondition | TPrismaFieldFilter
 }
 
 export type TPrismaOrderBy = {

--- a/src/adapters/prisma/utils/parseWhere.ts
+++ b/src/adapters/prisma/utils/parseWhere.ts
@@ -3,6 +3,7 @@ import isObject from 'lodash.isobject'
 import {
   TCondition,
   TSearchCondition,
+  TWhereCondition,
   TWhereField,
   TWhereOperator,
 } from '../../../types'
@@ -11,6 +12,7 @@ import {
   TPrismaFieldFilter,
   TPrismaWhereOperator,
   TPrismaWhereField,
+  TPrismaRelationFitler,
 } from '../types'
 
 const operatorsAssociation: {
@@ -41,22 +43,13 @@ const getSearchValue = (originalValue: any): TSearchCondition => {
   return originalValue
 }
 
-/**
- * This function is used to parse simple fields
- * but in the near future it will be used to also
- * handle nested fields
- */
-// const parseRecursiveField = (
-//   where: TCondition,
-//   manyRelations: string[]
-// ): TPrismaFieldFilter => {
-//   const parsed: TPrismaFieldFilter = {}
+const isRelation = (key: string, manyRelations: string[]): boolean => {
+  // Get the key containing . and remove the property name
+  const splitKey = key.split('.')
+  splitKey.splice(-1, 1)
 
-//   Object.keys(where).forEach((field) => {
-//   })
-
-//   return parsed
-// }
+  return manyRelations.includes(splitKey.join('.'))
+}
 
 const parseSimpleField = (value: TCondition) => {
   const operator = Object.keys(value)[0]
@@ -69,13 +62,18 @@ const parseSimpleField = (value: TCondition) => {
   }
 }
 
-const parseObjectCombination = (obj: TCondition): TPrismaFieldFilter => {
+const parseObjectCombination = (
+  obj: TCondition,
+  manyRelations: string[]
+): TPrismaFieldFilter => {
   const parsed: TPrismaFieldFilter = {}
 
   Object.keys(obj).forEach((key) => {
     const val = obj[key]
 
-    if (isPrimitive(val)) {
+    if (isRelation(key, manyRelations)) {
+      parseRelation(val, key, parsed, manyRelations)
+    } else if (isPrimitive(val)) {
       parsed[key] = val as TSearchCondition
     } else if (isObject(val)) {
       const fieldResult = parseSimpleField(val as TCondition)
@@ -89,43 +87,118 @@ const parseObjectCombination = (obj: TCondition): TPrismaFieldFilter => {
   return parsed
 }
 
+const basicParse = (
+  value: string | number | boolean | TCondition | Date | TWhereCondition,
+  key: string,
+  parsed: TPrismaWhereField,
+  manyRelations: string[]
+) => {
+  if (isPrimitive(value)) {
+    parsed[key] = getSearchValue(value)
+  } else {
+    switch (key) {
+      case '$or': {
+        if (isObject(value)) {
+          parsed.OR = parseObjectCombination(value as TCondition, manyRelations)
+        }
+        break
+      }
+      case '$and': {
+        if (isObject(value)) {
+          parsed.AND = parseObjectCombination(
+            value as TCondition,
+            manyRelations
+          )
+        }
+        break
+      }
+      case '$not': {
+        if (isObject(value)) {
+          parsed.NOT = parseObjectCombination(
+            value as TCondition,
+            manyRelations
+          )
+        }
+        break
+      }
+      default: {
+        parsed[key] = parseSimpleField(value as TCondition)
+        break
+      }
+    }
+  }
+}
+
+const parseRelation = (
+  value: string | number | boolean | Date | TCondition | TWhereCondition,
+  key: string,
+  parsed: TPrismaWhereField,
+  manyRelations: string[]
+) => {
+  // Reverse the keys so that we can format our object by nesting
+  const fields = key.split('.').reverse()
+  let formatFields = {}
+  fields.forEach((field, index) => {
+    // If we iterate over the property name, which is index 0, we parse it like a normal field
+    if (index === 0) {
+      basicParse(value, field, formatFields, manyRelations)
+    }
+    // Else we format the relation filter in the prisma way
+    else {
+      formatFields = {
+        [field]: {
+          some: formatFields,
+        },
+      }
+    }
+  })
+  // Retrieve the main relation field
+  const initialFieldKey = fields.reverse()[0]
+  // Retrieve the old parsed version
+  const oldParsed = parsed[initialFieldKey] as TPrismaRelationFitler
+  // Format correctly in the prisma way
+  parsed[initialFieldKey] = {
+    some: {
+      // @ts-ignore
+      ...(oldParsed?.some || {}),
+      ...formatFields[initialFieldKey].some,
+    },
+  }
+}
+
 export const parsePrismaWhere = (
   where: TWhereField,
-  // Not used currently, will be used for a future version
   manyRelations: string[]
 ): TPrismaWhereField => {
   const parsed: TPrismaWhereField = {}
 
   Object.keys(where).forEach((key) => {
     const value = where[key]
-
-    if (isPrimitive(value)) {
-      parsed[key] = getSearchValue(value)
+    /**
+     * If the key without property name is a relation
+     *
+     * We want the following example input:
+     *
+     * posts.author.id: 1
+     *
+     * to output
+     *
+     * {
+     *  posts: {
+     *    some: {
+     *      author: {
+     *        some: {
+     *          id: 1
+     *        }
+     *      }
+     *    }
+     *  }
+     * }
+     */
+    if (isRelation(key, manyRelations)) {
+      parseRelation(value, key, parsed, manyRelations)
     } else {
-      switch (key) {
-        case '$or': {
-          if (isObject(value)) {
-            parsed.OR = parseObjectCombination(value as TCondition)
-          }
-          break
-        }
-        case '$and': {
-          if (isObject(value)) {
-            parsed.AND = parseObjectCombination(value as TCondition)
-          }
-          break
-        }
-        case '$not': {
-          if (isObject(value)) {
-            parsed.NOT = parseObjectCombination(value as TCondition)
-          }
-          break
-        }
-        default: {
-          parsed[key] = parseSimpleField(value as TCondition)
-          break
-        }
-      }
+      basicParse(value, key, parsed, manyRelations)
     }
   })
 

--- a/src/queryParser.ts
+++ b/src/queryParser.ts
@@ -84,7 +84,7 @@ export const parseQuery = (queryString?: string): IParsedQueryParams => {
     }
 
     return {
-      ...query,
+      originalQuery: query,
       ...parsedQuery,
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,5 +94,7 @@ export interface IParsedQueryParams {
   limit?: number
   skip?: number
   distinct?: string
-  [key: string]: any
+  originalQuery?: {
+    [key: string]: any
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,6 +621,18 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@prisma/client@^2.0.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.14.0.tgz#a57ef8f3c41127f84ebe5f69bd01a966b204cdc2"
+  integrity sha512-0PiiZ2maM9OP/G5mynzftvD4DFrtibeyvZf5U7Be360mtSvgLHQhZ/CHbChb0BVeWeyJuTmAqqni98LcdVgttw==
+  dependencies:
+    "@prisma/engines-version" "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1"
+
+"@prisma/engines-version@2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1":
+  version "2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.14.0-28.5d491261d382a2a5ffdc71de17072b0e409f1cc1.tgz#ffd22601a18d74040653f6f8f518026cbc1bee3e"
+  integrity sha512-Oz3yNV//9UTJ+ral5tF6Ryb/MLfOE3+2F3/bH4waTbNRDd/zXKoS3jTI3ViU8yRQ1AsOQa9/pV/kXSlxgtAh8Q==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"


### PR DESCRIPTION
For prisma, allows the following where filter

`{"posts.title": {"$cont": "Hello"}}`

to

```
{
  posts: {
    some: {
      title: {
        contains: "Hello"
      }
    }
  }
}
```

This works when adding the relation to the `manyRelations` field of the PrismaAdapter, like so: `manyRelations: ['posts']`