### PR TITLE
Use resource name in 404 errors

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -127,6 +127,7 @@ function NextCrud<T, Q = any>({
               await getOneHandler({
                 ...params,
                 resourceId: resourceIdFormatted,
+                resourceName,
               })
               break
             case RouteType.READ_ALL:
@@ -139,6 +140,7 @@ function NextCrud<T, Q = any>({
               await updateHandler<T, Q>({
                 ...params,
                 resourceId: resourceIdFormatted,
+                resourceName,
                 body,
               })
               break
@@ -146,6 +148,7 @@ function NextCrud<T, Q = any>({
               await deleteHandler<T, Q>({
                 ...params,
                 resourceId: resourceIdFormatted,
+                resourceName,
               })
               break
             case null:

--- a/src/handlers/deleteHandler.ts
+++ b/src/handlers/deleteHandler.ts
@@ -8,6 +8,7 @@ async function deleteHandler<T, Q>({
   adapter,
   response,
   resourceId,
+  resourceName,
   query,
   request,
   middlewares,
@@ -30,7 +31,7 @@ async function deleteHandler<T, Q>({
       }
     )
   } else {
-    throw new HttpError(404, `resource ${resourceId} not found`)
+    throw new HttpError(404, `${resourceName} ${resourceId} not found`)
   }
 }
 

--- a/src/handlers/getOne.ts
+++ b/src/handlers/getOne.ts
@@ -8,6 +8,7 @@ async function getOneHandler<T, Q>({
   adapter,
   response,
   resourceId,
+  resourceName,
   query,
   middlewares,
   request,
@@ -15,7 +16,7 @@ async function getOneHandler<T, Q>({
   const resource = await adapter.getOne(resourceId, query)
 
   if (!resource) {
-    throw new HttpError(404, `resource ${resourceId} not found`)
+    throw new HttpError(404, `${resourceName} ${resourceId} not found`)
   }
 
   await executeMiddlewares(

--- a/src/handlers/updateHandler.ts
+++ b/src/handlers/updateHandler.ts
@@ -11,6 +11,7 @@ async function updateHandler<T, Q>({
   response,
   body,
   resourceId,
+  resourceName,
   query,
   middlewares,
   request,
@@ -33,7 +34,7 @@ async function updateHandler<T, Q>({
       }
     )
   } else {
-    throw new HttpError(404, `resource ${resourceId} not found`)
+    throw new HttpError(404, `${resourceName} ${resourceId} not found`)
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface IHandlerParams<T, Q> {
 export interface IUniqueResourceHandlerParams<T, Q>
   extends IHandlerParams<T, Q> {
   resourceId: string | number
+  resourceName: string
 }
 
 export interface IAdapter<T, Q> {


### PR DESCRIPTION
This should help debug errors on the client side and display better error messages.

Example:
```diff
- Not Found: resource 123 not found
+ Not Found: user 123 not found
```

Note: this may require some tweaking due to the pluralisation of `resourceName`.