### PR TITLE
Feature/nextjs apierror class support

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -31,6 +31,7 @@ import {
   getSwaggerPaths,
   getSwaggerTags,
 } from './swagger/utils'
+import { ApiError } from 'next/dist/next-server/server/api-utils'
 
 type TCallback<T extends any = undefined> = (
   req: NextApiRequest,
@@ -235,7 +236,7 @@ function NextCrud<T, Q = any, M extends string = string>({
               break
           }
         } catch (e) {
-          if (adapter.handleError && !(e instanceof HttpError)) {
+          if (adapter.handleError && !(e instanceof ApiError)) {
             adapter.handleError(e)
           } else {
             throw e
@@ -250,7 +251,7 @@ function NextCrud<T, Q = any, M extends string = string>({
       await onSuccess?.(req, res)
     } catch (e) {
       await onError?.(req, res, e)
-      if (e instanceof HttpError) {
+      if (e instanceof ApiError) {
         res.status(e.statusCode).send(e.message)
       } else {
         res.status(500).send(e.message)

--- a/src/httpError.ts
+++ b/src/httpError.ts
@@ -1,10 +1,11 @@
 import * as http from 'http'
+import { ApiError } from 'next/dist/next-server/server/api-utils'
 
-export default class HttpError extends Error {
+export default class HttpError extends ApiError {
   statusCode: number
 
   constructor(code: number, message?: string) {
-    super(`${http.STATUS_CODES[code]}: ${message}`)
+    super(code, `${http.STATUS_CODES[code]}: ${message}`)
     this.name = 'HttpError'
     this.statusCode = code
   }


### PR DESCRIPTION
This pull request is to share the default way of throw an error in NextJS API handlers, instead to use a exclusive error class of the lib.

I was changed the HttpError extended class from Error to a NextJS class named ApiError ( 
used to throw the error by default ), imported from next/dist/next-server/server/api-utils, and in the instanceof check, I used the NextJS ApiError class to get the status code and the message.

In this way, is more common to have compartibility with other libs.

You will not have the described http error if use directly the ApiError instead of HttpError, but is possible to add the description if it's important

Sorry about any mistakes in the text, i'm learning english yet
