### PR TITLE
Fix 'includes' typo

### DIFF
--- a/docs/pages/api-docs/adapters.mdx
+++ b/docs/pages/api-docs/adapters.mdx
@@ -52,7 +52,7 @@ Example:
 }
 ```
 
-#### includes
+#### include
 
 Same as [select](#select)
 


### PR DESCRIPTION
The [Adapters docs page](https://next-crud.js.org/api-docs/adapters#includes) lists "includes" as a property of the `query` object passed to `parseQuery`. The property is the singular form, "include". This PR fixes the typo on the docs page.