### PR TITLE
Prisma v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Check Types
         run: yarn tsc --noEmit
       - name: Prepare prisma for tests
-        run: yarn add @prisma/client@^4 && cd __tests__/adapters/prisma && npx prisma@4 db push
+        run: yarn test:prepare
       - name: Run tests
         run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 coverage/
 *.db
 .DS_Store
+.env*

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint",
     "prepublishOnly": "yarn lint && yarn build",
     "test": "jest -i",
+    "test:prepare": "yarn add @prisma/client@^5 && cd __tests__/adapters/prisma && npx prisma@5 db push",
     "watch": "tsc --watch"
   },
   "devDependencies": {
@@ -37,7 +38,7 @@
     "typescript": "^4.1.2"
   },
   "optionalDependencies": {
-    "@prisma/client": ">=2",
+    "@prisma/client": "^5",
     "prisma-json-schema-generator": "^3.0.1"
   },
   "husky": {
@@ -52,6 +53,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.set": "^4.3.2",
     "path-to-regexp": "^6.2.0",
+    "pluralize": "^8.0.0",
     "qs": "^6.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.1.2"
   },
   "optionalDependencies": {
-    "@prisma/client": "^5",
+    "@prisma/client": ">=2",
     "prisma-json-schema-generator": "^3.0.1"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "yarn clean && tsc",
+    "build": "yarn clean && ./node_modules/.bin/tsc",
     "clean": "rimraf dist",
     "lint": "eslint",
     "prepublishOnly": "yarn lint && yarn build",
@@ -35,7 +35,7 @@
     "node-mocks-http": "^1.12.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "typescript": "^5.2.2"
   },
   "optionalDependencies": {
     "@prisma/client": ">=2",

--- a/src/adapters/prisma/utils/parseWhere.ts
+++ b/src/adapters/prisma/utils/parseWhere.ts
@@ -1,4 +1,3 @@
-import { types } from 'util'
 import isObject from 'lodash.isobject'
 import {
   TCondition,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,3 +224,11 @@ export const getAccessibleRoutes = (
 
   return accessibleRoutes
 }
+
+/**
+ * Converts the first character of a word to lower case
+ * @param name
+ */
+export function lowerCase(name: string): string {
+  return name.substring(0, 1).toLowerCase() + name.substring(1)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,10 +5715,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 undici@5.7.0:
   version "5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,12 +602,12 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz#cea9792bfcf556c87ded17c6ac729348697bb632"
   integrity sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==
 
-"@prisma/client@>=2":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.1.1.tgz#f4012631528049c22d12b212846dcf503db33cfe"
-  integrity sha512-8ud8vVFMIg37yrkZ4wPpjKoMxFbCL0Pesq5eyLnag/s0LTKsVEN7ZBIQq9JzWW+AUqOzGKXr2Jt4Sl8xdGI99w==
+"@prisma/client@^5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.2.0.tgz#cbfdd440614b38736563a7999f39922fcde0ed50"
+  integrity sha512-AiTjJwR4J5Rh6Z/9ZKrBBLel3/5DzUNntMohOy7yObVnVoTNVFi2kvpLZlFuKO50d7yDspOtW6XBpiAd0BVXbQ==
   dependencies:
-    "@prisma/engines-version" "3.1.0-24.c22652b7e418506fab23052d569b85d3aec4883f"
+    "@prisma/engines-version" "5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f"
 
 "@prisma/debug@4.1.0":
   version "4.1.0"
@@ -639,10 +639,10 @@
     strip-ansi "6.0.1"
     undici "5.7.0"
 
-"@prisma/engines-version@3.1.0-24.c22652b7e418506fab23052d569b85d3aec4883f":
-  version "3.1.0-24.c22652b7e418506fab23052d569b85d3aec4883f"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.1.0-24.c22652b7e418506fab23052d569b85d3aec4883f.tgz#f9908eb7808f2a546634398063942eaecb2474ef"
-  integrity sha512-EuEMKLuwIcBO7uInZQHeG1yaywcfl32Tq8TDf5tgLvblk+ka70sej7S67lh3BV5gXMLTc3GdthSHPfDqZEK5uA==
+"@prisma/engines-version@5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f":
+  version "5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f.tgz#11366e7ff031c908debf4983248d40046016de37"
+  integrity sha512-jsnKT5JIDIE01lAeCj2ghY9IwxkedhKNvxQeoyLs6dr4ZXynetD0vTy7u6wMJt8vVPv8I5DPy/I4CFaoXAgbtg==
 
 "@prisma/engines@4.1.0":
   version "4.1.0"
@@ -4574,6 +4574,11 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,7 +602,7 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.5.0.tgz#cea9792bfcf556c87ded17c6ac729348697bb632"
   integrity sha512-wlYG/U6ddW1ilXslnDLLQYJ8nd97W8JJTTfwkGhubx6dzW6SUkd+N4/MzTjjyZlrHQunxHtkHFvVpUKiROvFDw==
 
-"@prisma/client@^5":
+"@prisma/client@>=2":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.2.0.tgz#cbfdd440614b38736563a7999f39922fcde0ed50"
   integrity sha512-AiTjJwR4J5Rh6Z/9ZKrBBLel3/5DzUNntMohOy7yObVnVoTNVFi2kvpLZlFuKO50d7yDspOtW6XBpiAd0BVXbQ==


### PR DESCRIPTION
Hi @foyarash 👋

I tried my hand at upgrading next-crud to `@prisma/client^5`.

Here are the key changes:

1. In `getPrismaClientModels`, I've added an additional `else if` clause to retrieve the models from `prismaClient._runtimeDataModel.models`
2. The `mappings` property from the `dmmf` object was removed. See https://github.com/prisma/prisma/pull/18828 for more info.
3. In `mapModelsToRouteNames`, if `this.dmmf.mappingsMap[model].plural` isn't present, I am deriving the pluralized version of the model name as was being done by the prisma team when creating the mappings object.
4. Added a `test:prepare` script to help make running tests locally a little easier.
 
PS: This is my first real code contribution to an open source project, so happy to hear any feedback or make any suggested changes!

Closes #57 