### PR TITLE
Typescript upgrade & Small convenience changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Check Types
         run: yarn tsc --noEmit
       - name: Prepare prisma for tests
-        run: yarn add @prisma/client@^4 && cd __tests__/adapters/prisma && npx prisma@4 db push
+        run: yarn test:prepare
       - name: Run tests
         run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 coverage/
 *.db
 .DS_Store
+.env*

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint",
     "prepublishOnly": "yarn lint && yarn build",
     "test": "jest -i",
+    "test:prepare": "yarn add @prisma/client@^5 && cd __tests__/adapters/prisma && npx prisma@5 db push",
     "watch": "tsc --watch"
   },
   "devDependencies": {
@@ -39,7 +40,7 @@
     "typescript": "^5.2.2"
   },
   "optionalDependencies": {
-    "@prisma/client": ">=5",
+    "@prisma/client": "^5",
     "prisma-json-schema-generator": "^3.0.1"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "yarn clean && tsc",
+    "build": "yarn clean && ./node_modules/.bin/tsc",
     "clean": "rimraf dist",
     "lint": "eslint",
     "prepublishOnly": "yarn lint && yarn build",
@@ -36,7 +36,7 @@
     "prisma-json-schema-generator": "^4.0.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.2"
+    "typescript": "^5.2.2"
   },
   "optionalDependencies": {
     "@prisma/client": ">=5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,10 +5663,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
#### Purpose

This pull request (as discussed in #58):
- Upgrades TS to the latest version i.e. `5.2.2`
- Adds `.env*` to the `.gitignore` file
- Creates a `test:prepare` script to be used from the command line & in gh actions

