### PR TITLE
fix: Enable getRouteType() to parse full urls

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -172,6 +172,18 @@ describe('getRouteType with query params', () => {
     })
   })
 
+  it('should return CREATE type for full URL', () => {
+    expect(
+      getRouteType({
+        method: 'POST',
+        url: 'http://localhost:3000/api/users?q=1',
+        resourceName: 'users',
+      })
+    ).toEqual<GetRouteType>({
+      routeType: RouteType.CREATE,
+    })
+  })
+
   it('should return UPDATE type', () => {
     expect(
       getRouteType({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const getRouteType = ({
   resourceName,
 }: GetRouteTypeParams): GetRouteType | null => {
   // Exclude the query params from the path
-  const realPath = url.split('?')[0]
+  const realPath = (url.startsWith("http")) ? new URL(url).pathname : url.split('?')[0]
 
   if (!realPath.includes(`/${resourceName}`)) {
     throw new Error(


### PR DESCRIPTION
getRouteType() expects url to be a path like `/api/users`.  But when using AppRouter the url passed is indeed a full url similar to `https://yourhost.com/api/users`.  As a result, the matchers in getRouteType() fail to properly return the correct routeType.  This small patch extracts the path from a full url so that the route type parsing works.